### PR TITLE
data should not install right under the CMAKE_INSTALL_PREFIX

### DIFF
--- a/cmake/templates/python_setuptools_install.sh.in
+++ b/cmake/templates/python_setuptools_install.sh.in
@@ -38,4 +38,4 @@ echo_and_run /usr/bin/env \
     build --build-base "@CMAKE_CURRENT_BINARY_DIR@" \
     install --single-version-externally-managed \
     $DESTDIR_ARG \
-    @SETUPTOOLS_ARG_EXTRA@ --prefix="@CMAKE_INSTALL_PREFIX@" --install-scripts="@CMAKE_INSTALL_PREFIX@/@CATKIN_GLOBAL_BIN_DESTINATION@"
+    @SETUPTOOLS_ARG_EXTRA@ --prefix="@CMAKE_INSTALL_PREFIX@" --install-scripts="@CMAKE_INSTALL_PREFIX@/@CATKIN_GLOBAL_BIN_DESTINATION@" --install-data="@CMAKE_INSTALL_PREFIX@/@CATKIN_GLOBAL_SHARE_DESTINATION@"


### PR DESCRIPTION
First of all, thanks for developping this pakcage. This is exactly what I need.

Not sure if `install/share/<package>/<data>` is the right place, but I feel data should not installed under `install/<data>` 

I have confirmed this with https://github.com/pfnet/chainercv/blob/master/setup.py