### PR TITLE
Added option NOSE_OPT to catkin_add_nosetests func

### DIFF
--- a/cmake/nosetests.cmake.in
+++ b/cmake/nosetests.cmake.in
@@ -23,6 +23,9 @@ _generate_function_if_testing_is_disabled("catkin_add_nosetests")
 #   tests (this option can only be used when the ``path`` argument is a
 #   file  but not when it is a directory)
 # :type WORKING_DIRECTORY: string
+# :param NOSE_OPT: additional options to be used to run pytest, this param
+#   should be used only if the other ones do not fulfill you requirements to
+#   properly run your pytests.
 #
 # @public
 #
@@ -34,7 +37,8 @@ function(catkin_add_nosetests path)
     return()
   endif()
 
-  cmake_parse_arguments(_nose "" "TIMEOUT;WORKING_DIRECTORY" "DEPENDENCIES" ${ARGN})
+
+  cmake_parse_arguments(_nose "" "TIMEOUT;WORKING_DIRECTORY;NOSE_OPT" "DEPENDENCIES" ${ARGN})
   if(NOT _nose_TIMEOUT)
     set(_nose_TIMEOUT 60)
   endif()
@@ -79,8 +83,8 @@ function(catkin_add_nosetests path)
   else()
     set(tests "${_path_name}")
   endif()
-  set(cmd ${cmd} "${CATKIN_ENV} ${CATKIN_PIP_NOSETESTS} -P --process-timeout=${_nose_TIMEOUT} ${tests} --with-xunit --xunit-file=${output_path}/nosetests-${output_file_name}.xml${_covarg}")
-  catkin_run_tests_target("nosetests" ${output_file_name} "nosetests-${output_file_name}.xml" COMMAND ${cmd} DEPENDENCIES ${_nose_DEPENDENCIES} WORKING_DIRECTORY ${_nose_WORKING_DIRECTORY})
+  set(cmd ${cmd} "${CATKIN_ENV} ${CATKIN_PIP_NOSETESTS} -P --process-timeout=${_nose_TIMEOUT} ${tests} ${_nose_NOSE_OPT} --with-xunit --xunit-file=${output_path}/nosetests-${output_file_name}.xml${_covarg}")
+  catkin_run_tests_target("nosetests" ${output_file_name}  "nosetests-${output_file_name}.xml" COMMAND ${cmd} DEPENDENCIES ${_nose_DEPENDENCIES} WORKING_DIRECTORY ${_nose_WORKING_DIRECTORY})
 endfunction()
 
 # Providing another catkin nosetests usage...

--- a/cmake/pytest.cmake.in
+++ b/cmake/pytest.cmake.in
@@ -23,6 +23,10 @@ _generate_function_if_testing_is_disabled("catkin_add_pytests")
 #   tests (this option can only be used when the ``path`` argument is a
 #   file  but not when it is a directory)
 # :type WORKING_DIRECTORY: string
+# :param PYTEST_OPT: additional options to be used to run pytest, this param
+#   should be used only if the other ones do not fullfill you requirements to
+#   properly run your pytests.
+# :type PYTEST_OPT: string
 #
 # @public
 #
@@ -34,7 +38,7 @@ function(catkin_add_pytests path)
     return()
   endif()
 
-  cmake_parse_arguments(_pytest "" "TIMEOUT;WORKING_DIRECTORY" "DEPENDENCIES" ${ARGN})
+  cmake_parse_arguments(_pytest "" "TIMEOUT;WORKING_DIRECTORY;PYTEST_OPT" "DEPENDENCIES" ${ARGN})
   if(NOT _pytest_TIMEOUT)
     set(_pytest_TIMEOUT 60)
   endif()
@@ -74,7 +78,7 @@ function(catkin_add_pytests path)
   get_filename_component(output_path "${output_path}" ABSOLUTE)
   set(cmd "${CMAKE_COMMAND} -E make_directory ${output_path}")
   set(tests "${_path_name}")
-  set(cmd ${cmd} "${CATKIN_ENV} ${CATKIN_PIP_PYTEST} --timeout=${_pytest_TIMEOUT} ${tests} --junit-xml ${output_path}/pytests-${output_file_name}.xml ${_covarg}")
+  set(cmd ${cmd} "${CATKIN_ENV} ${CATKIN_PIP_PYTEST} --timeout=${_pytest_TIMEOUT} ${tests} ${_pytest_PYTEST_OPT} --junit-xml ${output_path}/pytests-${output_file_name}.xml ${_covarg}")
   catkin_run_tests_target("pytests" ${output_file_name} "pytests-${output_file_name}.xml" COMMAND ${cmd} DEPENDENCIES ${_pytest_DEPENDENCIES} WORKING_DIRECTORY ${_pytest_WORKING_DIRECTORY})
 endfunction()
 


### PR DESCRIPTION
In order to use some specific option for nosetests we now have a NOSE_OPT
parameter that allow to use some customs options for launching nosetests