### PR TITLE
no such option: --prefix

### DIFF
--- a/cmake/catkin-pip-runcmd.cmake.in
+++ b/cmake/catkin-pip-runcmd.cmake.in
@@ -27,7 +27,7 @@ function(catkin_pip_runcmd)
     execute_process(
       # Note we need to use catkin_env to make sure our envhook is properly loaded
       COMMAND ${CATKIN_ENV} ${CATKIN_PIP_COMMAND}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      WORKING_DIRECTORY ${CATKIN_PIP_ENV}/@CATKIN_PIP_GLOBAL_PYTHON_DESTINATION@
       RESULT_VARIABLE PIP_RESULT
       OUTPUT_VARIABLE PIP_VARIABLE
       ERROR_VARIABLE PIP_ERROR


### PR DESCRIPTION
Hi, I'm a user using the cakint_pip.
caktin_pip is a great solution to integrate with python packages but sometimes while building included catkin_pip package occur "no such option: --prefix", so I changed WORKING_DIRECTORY to the site-packages directory to search python the fist path.
I would appreciate your feedback. 