### PR TITLE
install pip dependencies using local virtualenv, also support install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ catkin_package(
   catkin-pip.cmake
   catkin-pip-runcmd.cmake
   catkin-pip-package.cmake
+  catkin-pip-package-virtualenv.cmake
   catkin-pip-prefix.cmake
   catkin-pip-requirements.cmake
   pytest.cmake

--- a/cmake/catkin-pip-package-virtualenv.cmake.in
+++ b/cmake/catkin-pip-package-virtualenv.cmake.in
@@ -20,49 +20,27 @@ macro(catkin_pip_package_virtualenv package_name)
 
   unset(CATKIN_VIRTUALENV CACHE)
   find_program(CATKIN_VIRTUALENV NAMES virtualenv)
+  # call catkin_package() to set CATKIN_PACKAGE_SHARE_DESTINATION
 
-  # catkin_pip_package call catkin_package() to set CATKIN_PACKAGE_SHARE_DESTINATION
-  catkin_pip_package(${package_name} ${ARGN})
+  set(CATKIN_VIRTUALENV_PATH_${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/catkin_pip_env CACHE PATH "The virtual eivironment for each package")
+  message("-- Set local virtual env path to CATKIN_VIRTUALENV_PATH_${PROJECT_NAME} : ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}}")
+  message("-- Install local virutalenv to ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}}")
+  catkin_pip_runcmd(python ${CATKIN_VIRTUALENV} -q --system-site-packages ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
+  ### HACK somehow virtualenv create local dir, which shows two python.exe when we run `rosrun <pkg> python`
+  catkin_pip_runcmd(cmake -E remove_directory ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}}/local)
 
-  if (CATKIN_VIRTUALENV)
-    #set(CATKIN_VIRTUALENV "${CATKIN_VIRTUALENV} -q")  # we can add all default basic options here.
-  else ()
-    message(FATAL_ERROR "Could not find virtualenv")
-  endif()
+  ## OVERRIDE catkin_pip_env
+  unset(CATKIN_PIP_ENV CACHE)
+  set(CATKIN_PIP_ENV ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
 
-  # runnig the virtualenv command (configure time)
-  set(CATKIN_VIRTUALENV_PATH_${package_name} ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/catkin_pip_env CACHE PATH "The virtual eivironment for each package")
-  catkin_pip_runcmd(${CATKIN_VIRTUALENV} --system-site-packages ${CATKIN_VIRTUALENV_PATH_${package_name}})
+  ## copy virtualenv path to install directory
+  install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/catkin_pip_env/
+    DESTINATION share/${PROJECT_NAME}/catkin_pip_env
+    USE_SOURCE_PERMISSIONS
+    PATTERN "${PROJECT_NAME}.egg-link" EXCLUDE
+    )
 
-  ### HACK somehow virtualenv create local dir
-  catkin_pip_runcmd(cmake -E remove_directory ${CATKIN_VIRTUALENV_PATH_${package_name}}/local)
-
-  # Setting up our environment (for devel space only)
-  # Needed in case user call this directly (configure time)
-  ## NOTE This will set CATKIN_PIP within virtualenv
-  catkin_pip_setup_prefix(${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
-  
-  ### OVERRIDE CATKIN_PIP_INSTALL_DEVEL_OUTPUTS is defined in catkin_pip_install_devel_target and used within catkin_pip_package 
-  catkin_pip_runcmd(${CATKIN_PIP} install -e ${CMAKE_CURRENT_SOURCE_DIR} --prefix "${CATKIN_VIRTUALENV_PATH_${package_name}}")
-
+  ## RUN catkin_pip_package
+  catkin_pip_package(${package_name})
 endmacro()
-
-# Override catkin_pip_requirements to install using virtualenv pip
-function(catkin_pip_requirements requirements_txt)
-  # Setting up our environment (for devel space only)
-  # Needed in case user call this directly (configure time)
-  if (CATKIN_VIRTUALENV)
-    catkin_pip_setup_prefix(${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
-  else()
-    catkin_pip_setup_prefix(${CATKIN_PIP_ENV})
-  endif()
-
-  # runnig the pip command (configure time)
-  if (CATKIN_VIRTUALENV) ## USE VIRTUALENV
-    catkin_pip_runcmd(${CATKIN_PIP} install ${ARGN} -r ${requirements_txt} --ignore-installed --src ${CMAKE_SOURCE_DIR} --exists-action b)
-  else()
-    catkin_pip_runcmd(${CATKIN_PIP} install ${ARGN} -r ${requirements_txt} --ignore-installed --src ${CMAKE_SOURCE_DIR} --exists-action b --prefix "${CATKIN_DEVEL_PREFIX}")
-  endif()
-
-endfunction()
 

--- a/cmake/catkin-pip-package-virtualenv.cmake.in
+++ b/cmake/catkin-pip-package-virtualenv.cmake.in
@@ -1,0 +1,68 @@
+if ( CMAKE_BACKWARDS_COMPATIBILITY LESS 2.8 )
+	message ( FATAL_ERROR " CMAKE MINIMUM BACKWARD COMPATIBILITY REQUIRED : 2.8 !" )
+endif( CMAKE_BACKWARDS_COMPATIBILITY LESS 2.8 )
+
+# Enforcing one time include https://cmake.org/Wiki/CMake_Performance_Tips#Use_an_include_guard
+if(catkin_pip_target_virtualenv_included)
+  return()
+endif(catkin_pip_target_virtualenv_included)
+set(catkin_pip_target_virtualenv_included true)
+
+message(STATUS "Loading catkin-pip-package-virtualenv.cmake from ${CMAKE_CURRENT_LIST_DIR}... ")
+
+
+# catkin_pip_package override catkin_pip_package, otherwise CATKIN_PIP_ENV directory
+## ned to call `catkin_pip_requirements` after `catkin_pip_package_virtualenv`
+macro(catkin_pip_package_virtualenv package_name)
+  if (NOT ${package_name} STREQUAL ${PROJECT_NAME})
+    message(FATAL_ERROR "We assume package_name(${package_name}) is equal to PROJECT_NAME(${PROJECT_NAME})")
+  endif()
+
+  unset(CATKIN_VIRTUALENV CACHE)
+  find_program(CATKIN_VIRTUALENV NAMES virtualenv)
+
+  # catkin_pip_package call catkin_package() to set CATKIN_PACKAGE_SHARE_DESTINATION
+  catkin_pip_package(${package_name} ${ARGN})
+
+  if (CATKIN_VIRTUALENV)
+    #set(CATKIN_VIRTUALENV "${CATKIN_VIRTUALENV} -q")  # we can add all default basic options here.
+  else ()
+    message(FATAL_ERROR "Could not find virtualenv")
+  endif()
+
+  # runnig the virtualenv command (configure time)
+  set(CATKIN_VIRTUALENV_PATH_${package_name} ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/catkin_pip_env CACHE PATH "The virtual eivironment for each package")
+  catkin_pip_runcmd(${CATKIN_VIRTUALENV} --system-site-packages ${CATKIN_VIRTUALENV_PATH_${package_name}})
+
+  ### HACK somehow virtualenv create local dir
+  catkin_pip_runcmd(cmake -E remove_directory ${CATKIN_VIRTUALENV_PATH_${package_name}}/local)
+
+  # Setting up our environment (for devel space only)
+  # Needed in case user call this directly (configure time)
+  ## NOTE This will set CATKIN_PIP within virtualenv
+  catkin_pip_setup_prefix(${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
+  
+  ### OVERRIDE CATKIN_PIP_INSTALL_DEVEL_OUTPUTS is defined in catkin_pip_install_devel_target and used within catkin_pip_package 
+  catkin_pip_runcmd(${CATKIN_PIP} install -e ${CMAKE_CURRENT_SOURCE_DIR} --prefix "${CATKIN_VIRTUALENV_PATH_${package_name}}")
+
+endmacro()
+
+# Override catkin_pip_requirements to install using virtualenv pip
+function(catkin_pip_requirements requirements_txt)
+  # Setting up our environment (for devel space only)
+  # Needed in case user call this directly (configure time)
+  if (CATKIN_VIRTUALENV)
+    catkin_pip_setup_prefix(${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
+  else()
+    catkin_pip_setup_prefix(${CATKIN_PIP_ENV})
+  endif()
+
+  # runnig the pip command (configure time)
+  if (CATKIN_VIRTUALENV) ## USE VIRTUALENV
+    catkin_pip_runcmd(${CATKIN_PIP} install ${ARGN} -r ${requirements_txt} --ignore-installed --src ${CMAKE_SOURCE_DIR} --exists-action b)
+  else()
+    catkin_pip_runcmd(${CATKIN_PIP} install ${ARGN} -r ${requirements_txt} --ignore-installed --src ${CMAKE_SOURCE_DIR} --exists-action b --prefix "${CATKIN_DEVEL_PREFIX}")
+  endif()
+
+endfunction()
+

--- a/cmake/catkin-pip-package.cmake.in
+++ b/cmake/catkin-pip-package.cmake.in
@@ -49,6 +49,11 @@ function(catkin_pip_python_setup)
       assert(CATKIN_PIP_PYTHON_INSTALL_DIR)
       set(INSTALL_CMD_WORKING_DIRECTORY ${package_path})
 
+      set(__CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+      # tmp override CMAKE_INSTLAL_PREIFX for virutalenv setup
+      if (CATKIN_VIRTUALENV_PATH_${PROJECT_NAME})
+        set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/catkin_pip_env)
+      endif()
       if(NOT WIN32)
         set(INSTALL_SCRIPT
           ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_setuptools_install.sh)
@@ -64,10 +69,12 @@ function(catkin_pip_python_setup)
           ${INSTALL_SCRIPT}
           @ONLY)
       endif()
+      set(CMAKE_INSTALL_PREFIX ${__CMAKE_INSTALL_PREFIX})
 
       # generate python script which gets executed at install time
       configure_file(${catkin_EXTRAS_DIR}/templates/safe_execute_install.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
+
       install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
 
     # END : This is the end of catkin_python_setup copy
@@ -92,21 +99,18 @@ function(catkin_pip_target package_name)
 
     set(${PROJECT_NAME}_PIP_TARGET ${package_name} CACHE STRING "Make target generated to install this pip package as --editable for development")
 
+    catkin_pip_setup_prefix(${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
     # Note : environment should already be setup at configure time for devel
 
     # Then we can run the pip command
     # Note when installing in editable mode (for development) we shouldnt care about already installed versions.
     # However : https://github.com/asmodehn/catkin_pip/issues/58
     if(CATKIN_PIP_NO_DEPS)
-      if(NOT CATKIN_VIRTUALENV)
         catkin_pip_install_devel_target(${package_name} ${package_path} --no-dependencies --ignore-installed)
         #catkin_pip_runcmd(${CATKIN_PIP} install -e ${package_path} --no-dependencies --prefix "${CATKIN_DEVEL_PREFIX}" --ignore-installed)
-      endif()
     else()
-      if(NOT CATKIN_VIRTUALENV)
         catkin_pip_install_devel_target(${package_name} ${package_path} --ignore-installed)
         #catkin_pip_runcmd(${CATKIN_PIP} install -e ${package_path} --prefix "${CATKIN_DEVEL_PREFIX}" --ignore-installed)
-      endif()
     endif()
 
     if(NOT EXISTS ${package_path}/setup.py)

--- a/cmake/catkin-pip-package.cmake.in
+++ b/cmake/catkin-pip-package.cmake.in
@@ -98,11 +98,15 @@ function(catkin_pip_target package_name)
     # Note when installing in editable mode (for development) we shouldnt care about already installed versions.
     # However : https://github.com/asmodehn/catkin_pip/issues/58
     if(CATKIN_PIP_NO_DEPS)
+      if(NOT CATKIN_VIRTUALENV)
         catkin_pip_install_devel_target(${package_name} ${package_path} --no-dependencies --ignore-installed)
         #catkin_pip_runcmd(${CATKIN_PIP} install -e ${package_path} --no-dependencies --prefix "${CATKIN_DEVEL_PREFIX}" --ignore-installed)
+      endif()
     else()
+      if(NOT CATKIN_VIRTUALENV)
         catkin_pip_install_devel_target(${package_name} ${package_path} --ignore-installed)
         #catkin_pip_runcmd(${CATKIN_PIP} install -e ${package_path} --prefix "${CATKIN_DEVEL_PREFIX}" --ignore-installed)
+      endif()
     endif()
 
     if(NOT EXISTS ${package_path}/setup.py)

--- a/cmake/catkin-pip-requirements.cmake.in
+++ b/cmake/catkin-pip-requirements.cmake.in
@@ -28,7 +28,14 @@ function(catkin_pip_requirements requirements_txt)
     # Needed in case user call this directly (configure time)
     catkin_pip_setup_prefix(${CATKIN_PIP_ENV})
 
+    # If catkin_pip_use_viertualenv is set, install within package path, other wise install devel prefix
+    if(CATKIN_VIRTUALENV_PATH_${PROJECT_NAME})
+      set(_pip_install_prefix ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
+    else()
+      set(_pip_install_prefix ${CATKIN_DEVEL_PREFIX})
+    endif()
+
     # runnig the pip command (configure time)
-    catkin_pip_runcmd(${CATKIN_PIP} install ${ARGN} -r ${requirements_txt} --ignore-installed --src ${CMAKE_SOURCE_DIR} --exists-action b --prefix "${CATKIN_DEVEL_PREFIX}")
+    catkin_pip_runcmd(${CATKIN_PIP} install ${ARGN} -r ${requirements_txt} --ignore-installed --src ${CMAKE_SOURCE_DIR} --exists-action b --prefix "${_pip_install_prefix}")
 
 endfunction()

--- a/cmake/catkin-pip-runcmd.cmake.in
+++ b/cmake/catkin-pip-runcmd.cmake.in
@@ -43,11 +43,21 @@ endfunction()
 
 
 function(catkin_pip_install_devel_target package_name package_path)
+
+  # If catkin_pip_use_viertualenv is set, install within package path, other wise install devel prefix
+  if (CATKIN_VIRTUALENV_PATH_${PROJECT_NAME})
+    set(_pip_install_prefix ${CATKIN_VIRTUALENV_PATH_${PROJECT_NAME}})
+    set(CATKIN_PIP_INSTALL_DEVEL_OUTPUTS
+        ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/${CATKIN_PIP_PYTHON_INSTALL_DIR}/${package_name}.egg-link
+    )
+  else()
+    set(_pip_install_prefix ${CATKIN_DEVEL_PREFIX})
     set(CATKIN_PIP_INSTALL_DEVEL_OUTPUTS
         # ${CATKIN_DEVEL_PREFIX}/${CATKIN_PIP_PYTHON_INSTALL_DIR}/easy-install.pth
         # CAREFUL with multiple outputs : https://cmake.org/Bug/view.php?id=15116
         ${CATKIN_DEVEL_PREFIX}/${CATKIN_PIP_PYTHON_INSTALL_DIR}/${package_name}.egg-link
     )
+  endif()
 
     string(REPLACE ";" " " ARGN_STR "${ARGN}")
 
@@ -56,7 +66,7 @@ function(catkin_pip_install_devel_target package_name package_path)
 
 
     set(CATKIN_PIP_CMD ${CATKIN_ENV})
-    set(CATKIN_PIP_CMD_ARGS_STR "flock ${CATKIN_PIP_ENV}/catkin_pip.lock ${CATKIN_PIP} install -e ${package_path} --prefix ${CATKIN_DEVEL_PREFIX} ${ARGN_STR}")
+    set(CATKIN_PIP_CMD_ARGS_STR "flock ${CATKIN_PIP_ENV}/catkin_pip.lock ${CATKIN_PIP} install -e ${package_path} --prefix ${_pip_install_prefix} ${ARGN_STR}")
     # IF WE ARE PASSING EDITABLE PKG PATHS INTO PYTHONPATH we need to work around bug :
     # PYTHONPATH breaks pip install --editable Ref : https://github.com/pypa/pip/issues/4261
     # set(CATKIN_PIP_CMD_ARGS_STR "-c 'export PYTHONPATH=${CATKIN_DEVEL_PREFIX}/${CATKIN_PIP_PYTHON_INSTALL_DIR}:${CATKIN_PIP_ENV}/${CATKIN_PIP_PYTHON_INSTALL_DIR}\; ${CATKIN_PIP_CMD_ARGS_STR}'")

--- a/cmake/catkin-pip.cmake.in
+++ b/cmake/catkin-pip.cmake.in
@@ -30,6 +30,12 @@ IF ( NOT CATKIN_PIP_PACKAGE_FOUND )
     message ( FATAL_ERROR "${CMAKE_CURRENT_LIST_DIR}/catkin-pip-package.cmake Not Found !!!" )
 ENDIF ( NOT CATKIN_PIP_PACKAGE_FOUND )
 
+# protecting against missing cmake file dependency
+include ( "${CMAKE_CURRENT_LIST_DIR}/catkin-pip-package-virtualenv.cmake" RESULT_VARIABLE CATKIN_PIP_PACKAGE_VIRTUALENV_FOUND )
+IF ( NOT CATKIN_PIP_PACKAGE_VIRTUALENV_FOUND )
+    message ( FATAL_ERROR "${CMAKE_CURRENT_LIST_DIR}/catkin-pip-package-virtualenv.cmake Not Found !!!" )
+ENDIF ( NOT CATKIN_PIP_PACKAGE_VIRTUALENV_FOUND )
+
 # Setting our paths to package env-hooks provided by catkin-pip
 if ( NOT CATKIN_PIP_ENV_HOOKS_PATH )
     # templates should be found relative to our current path


### PR DESCRIPTION
this will install pip dependency to package-local virtual env, i.e. `share/${PACKAGE_NAME}/catkin_env`

to test this code, make workspace with this PR and test code (https://github.com/k-okada/gdown) use `catkin_make` or `catkin_make install`

```
install$ rosrun gdown python2
Python 2.7.12 (default, Nov 20 2017, 18:23:56) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import ez
>>> ez
<module 'ez' from '/home/k-okada/catkin_ws/ws_catkin_pip/install/share/gdown/catkin_pip_env/lib/python2.7/site-packages/ez/__init__.pyc'>
>>> import gdown
>>> gdown
<module 'gdown' from '/home/k-okada/catkin_ws/ws_catkin_pip/install/share/gdown/catkin_pip_env/lib/python2.7/dist-packages/gdown/__init__.pyc'>
 
```

To make deb file, you have to force install catkin_pip cmake files to `/opt/ros/kinetic`
```
sudo cp devel/share/catkin_pip/cmake/*.cmake /opt/ros/kinetic/share/catkin_pip/cmake/
cd src/gdown
rm -fr debian/ obj-x86_64-linux-gnu/ ../../install ../../build/ ../../devel/; catkin_make -C ../../ --make-args debbuild_gdown
```

Please try with your python package @yuyu2172 

My concern is that we have to run `pip install` during `dpkg -i`, to create runtme library based on your CUDA environment, and that is not supported by this approach nor dh-virtualenv, fpm...

c.f. https://github.com/pyros-dev/catkin_pip/issues/109